### PR TITLE
Simplify project schema

### DIFF
--- a/etelemetry_app/main.py
+++ b/etelemetry_app/main.py
@@ -10,7 +10,10 @@ def get_parser():
     parser.add_argument("--workers", default=1, help="worker processes")
     parser.add_argument("--reload", action="store_true", help="Reload app on change (dev only)")
     parser.add_argument(
-        "--proxy-headers", action="store_true", help="Accept incoming proxy headers"
+        "--proxy-headers", action="store_true", help="Accept incoming proxy headers",
+    )
+    parser.add_argument(
+        "--headers", nargs='*', help="Custom HTTP response headers as 'Name:Value' pairs",
     )
     return parser
 

--- a/etelemetry_app/server/database.py
+++ b/etelemetry_app/server/database.py
@@ -64,10 +64,9 @@ async def create_geoloc_table(table: str = 'geolocs') -> None:
         )
 
 
-async def create_project_tables(owner: str, repo: str) -> None:
-    table = f"{owner}/{repo}"
-    await create_project_table(table)
-    await create_user_table(f"{table}/users")
+async def create_project_tables(project) -> None:
+    await create_project_table(project)
+    await create_user_table(f"{project}/users")
 
 
 # Table insertion
@@ -120,11 +119,10 @@ async def insert_user(
 async def insert_project_data(project: Project) -> bool:
     data = await serialize(project.__dict__)
     # replace with a cache to avoid excessive db calls
-    await create_project_tables(project.owner, project.repo)
-    ptable = f"{project.owner}/{project.repo}"
-    utable = f"{ptable}/users"
+    await create_project_tables(project.project)
+    utable = f"{project.project}/users"
     await insert_project(
-        ptable,
+        project.project,
         language=data['language'],
         language_version=data['language_version'],
         timestamp=data['timestamp'],

--- a/etelemetry_app/server/schema.py
+++ b/etelemetry_app/server/schema.py
@@ -2,7 +2,6 @@ import strawberry
 from strawberry.scalars import JSON
 from strawberry.types import Info
 
-from etelemetry_app.server.connections import get_redis_connection
 from etelemetry_app.server.database import (
     insert_project_data,
     query_or_insert_geoloc,
@@ -28,11 +27,7 @@ class Query:
         projs = await query_projects()
         return projs
 
-    # This is the query we want!
-    # @strawberry.field
-    # async def get_project_from_name(self, name: str) -> Project:
 
-    # and this!
     @strawberry.field
     async def from_date_range(
         self,
@@ -68,9 +63,8 @@ class Mutation:
 
         # convert to Project and set defaults
         project = Project(
-            owner=p.owner,
-            repo=p.repo,
-            version=p.version,
+            project=p.project,
+            project_version=p.project_version,
             language=p.language,
             language_version=p.language_version,
             session=p.session,
@@ -84,8 +78,7 @@ class Mutation:
             process=Process(status=p.status),
         )
 
-        project_key = f'{project.owner}/{project.repo}'
-        fetched = await fetch_project_info(project_key)
+        fetched = await fetch_project_info(p.project)
 
         # return project info ASAP, assign data ingestion as a background task
         request = info.context['request']

--- a/etelemetry_app/server/types.py
+++ b/etelemetry_app/server/types.py
@@ -97,9 +97,8 @@ class Context:
 
 @strawberry.type
 class Project:
-    owner: str
-    repo: str
-    version: Version
+    project: str
+    project_version: Version
     language: str
     language_version: Version
     timestamp: DateTime
@@ -111,9 +110,8 @@ class Project:
 
 @strawberry.input
 class ProjectInput:
-    owner: str = strawberry.field(description="GitHub name that owns the project")
-    repo: str = strawberry.field(description="GitHub repository name of the project")
-    version: Version = strawberry.field(description="Project version being used")
+    project: str = strawberry.field(description="GitHub project in the form of 'owner/repo'")
+    project_version: Version = strawberry.field(description="Project version being used")
     language: str = strawberry.field(description="Programming language of project")
     language_version: Version = strawberry.field(description="Programming language version")
     # optional

--- a/examples/htp.py
+++ b/examples/htp.py
@@ -22,23 +22,20 @@ def _parser():
 
 def main(pargs=None):
     pargs = _parser().parse_args(pargs)
-    owner, repo = pargs.project.split('/')
 
     mutation = '''
         mutation {
         addProject(
         p: {
-        repo: "%s",
-        owner: "%s",
-        version: "%s",
+        project: "%s",
+        projectVersion: "%s",
         language: "python",
         languageVersion: "3.10.4",
         status: %s,
         userId: "%s",
         session: "%s",
         })}''' % (
-        repo,
-        owner,
+        pargs.project,
         pargs.version,
         pargs.status,
         pargs.user,


### PR DESCRIPTION
- Group `owner`/`repo` fields into `project`, since
all operations are combining them anyways

Also snuck in a new server flag, `--headers` to support custom response headers on startup.