### PR TITLE
ENH: Add rate-limiting to graphql schema

### DIFF
--- a/etelemetry_app/server/database.py
+++ b/etelemetry_app/server/database.py
@@ -188,18 +188,18 @@ async def query_or_insert_geoloc(ip: str) -> Record:
     """
     from hashlib import sha256
 
-    if ip == '127.0.0.1':
-        # ignore localhost testing
-        return
-
     await create_geoloc_table()
     hip = sha256(ip.encode()).hexdigest()
     pool = await get_db_connection_pool()
     async with pool.acquire() as conn:
         record = await conn.fetchrow(f'SELECT * FROM geolocs WHERE id = $1;', hip)
+
     if not record:
         data = await fetch_ipstack_data(ip)
-        print(data)
+        if data.get("success", True) is False:
+            print(f"Unable to fetch geoloc data: {data}")
+            return
+
         await insert_geoloc(
             hip,
             continent=data['continent_name'],

--- a/etelemetry_app/server/schema.py
+++ b/etelemetry_app/server/schema.py
@@ -1,3 +1,5 @@
+import os
+
 from graphql import ExecutionResult as GraphQLExecutionResult, GraphQLError
 from fastapi import Request, Response
 import strawberry
@@ -120,7 +122,8 @@ class Watchdog(Extension):
         """
         request = self.execution_context.context['request']
         response = self.execution_context.context['response']
-        await self.sliding_window_rate_limit(request, response)
+        if not os.getenv("ETELEMETRY_BYPASS_RATE_LIMIT", False):
+            await self.sliding_window_rate_limit(request, response)
         # check request size
         body = await request.body()
         if len(body) > self.MAX_REQUEST_BYTES:

--- a/etelemetry_app/server/schema.py
+++ b/etelemetry_app/server/schema.py
@@ -95,4 +95,4 @@ class Mutation:
         }
 
 
-SCHEMA = strawberry.Schema(query=Query, mutation=Mutation)
+SCHEMA = strawberry.Schema(query=Query, mutation=Mutation, auto_camel_case=False)

--- a/etelemetry_app/tests/test_server.py
+++ b/etelemetry_app/tests/test_server.py
@@ -1,11 +1,59 @@
+import os
+
 from fastapi.testclient import TestClient
+import pytest
 
 from etelemetry_app.server.app import app
 
-client = TestClient(app)
 
+os.environ["ETELEMETRY_BYPASS_RATE_LIMIT"] = "1"
+
+queries = {
+    'add_project': 'mutation{add_project(p:{project:"github/fetch",project_version:"3.6.2",language:"javascript",language_version:"1.7"})}',
+}
+
+
+client = TestClient(app)
 
 def test_server_startup_shutdown():
     res = client.get("/")
     assert res.status_code == 200
     assert res.json()["package"] == "etelemetry"
+
+
+@pytest.mark.parametrize(
+    'resolver_str',
+    [
+        queries['add_project'],
+    ],
+)
+def test_graphql_add_project(resolver_str):
+    res = client.post("/graphql", json={'query': resolver_str})
+    assert res.status_code == 200
+    output = res.json()['data']['add_project']
+    assert output['success'] is True
+    for k in ('bad_versions', 'cached', 'latest_version', 'message'):
+        assert k in output
+
+
+def test_graphql_big_request():
+    res = client.post(
+        "/graphql", json={'query': queries['add_project'].replace('javascript', 'x' * 300)}
+    )
+    assert res.status_code == 413
+    errors = res.json()['errors']
+    assert 'exceeds maximum size' in errors[0]['message']
+
+
+# def test_graphql_overload(monkeypatch):
+#     monkeypatch.delitem(os.environ, 'ETELEMETRY_BYPASS_RATE_LIMIT')
+#     client.post("/graphql", json={'query': queries['add_project']})
+    # with client as client_:
+    #     # 5 requests are fine
+    #     for i in range(5):
+    #         print(i)
+    #         res = client_.post("/graphql", json={'query': queries['add_project']})
+    #         res.status_code == 200
+    #     # anything more is not
+    #     res = client_.post("/graphql", json={'query': queries['add_project']})
+    #     assert res.status_code == 429


### PR DESCRIPTION
Adds rate limiting to graphql endpoint.

## TODOs
- ~Test whether adding a FastAPI middleware is a cleaner solution.~ 
  - Could not get this working, likely due to some WSGI/ASGI incompatibilities 
- Test rate limiting conditions
  - see below

<details>
<summary>RL testing</summary>

```
pytest etelemetry_app/tests/test_server.py
==================================================== test session starts ====================================================
platform darwin -- Python 3.10.4, pytest-7.1.2, pluggy-1.0.0
rootdir: /Users/mathiasg/code/et2/server
plugins: asyncio-0.18.3, anyio-3.5.0
asyncio: mode=legacy
collected 4 items                                                                                                           

etelemetry_app/tests/test_server.py ...F                                                                              [100%]

========================================================= FAILURES ==========================================================
___________________________________________________ test_graphql_overload ___________________________________________________

self = Connection<host=localhost,port=6379,db=0>

    async def read_response(self):
        """Read the response from a previously sent command"""
        try:
            async with self._lock:
                async with async_timeout.timeout(self.socket_timeout):
>                   response = await self._parser.read_response()

../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/aioredis/connection.py:900: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <aioredis.connection.HiredisParser object at 0x1042ad850>

    async def read_response(self) -> Union[EncodableT, List[EncodableT]]:
        if not self._stream or not self._reader:
            self.on_disconnect()
            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from None
    
        response: Union[
            EncodableT, ConnectionError, List[Union[EncodableT, ConnectionError]]
        ]
        # _next_response might be cached from a can_read() call
        if self._next_response is not False:
            response = self._next_response
            self._next_response = False
            return response
    
        response = self._reader.gets()
        while response is False:
>           await self.read_from_socket()

../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/aioredis/connection.py:537: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <aioredis.connection.HiredisParser object at 0x1042ad850>, timeout = None, raise_on_timeout = True

    async def read_from_socket(
        self,
        timeout: Union[float, None, _Sentinel] = SENTINEL,
        raise_on_timeout: bool = True,
    ):
        if self._stream is None or self._reader is None:
            raise RedisError("Parser already closed.")
    
        timeout = self._socket_timeout if timeout is SENTINEL else timeout
        try:
            async with async_timeout.timeout(timeout):
>               buffer = await self._stream.read(self._read_size)

../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/aioredis/connection.py:498: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <StreamReader transport=<_SelectorSocketTransport closing fd=16>>, n = 65536

    async def read(self, n=-1):
        """Read up to `n` bytes from the stream.
    
        If n is not provided, or set to -1, read until EOF and return all read
        bytes. If the EOF was received and the internal buffer is empty, return
        an empty bytes object.
    
        If n is zero, return empty bytes object immediately.
    
        If n is positive, this function try to read `n` bytes, and may return
        less or equal bytes than requested, but at least one byte. If EOF was
        received before any byte is read, this function returns empty byte
        object.
    
        Returned value is not limited with limit, configured at stream
        creation.
    
        If stream was paused, this function will automatically resume it if
        needed.
        """
    
        if self._exception is not None:
            raise self._exception
    
        if n == 0:
            return b''
    
        if n < 0:
            # This used to just loop creating a new waiter hoping to
            # collect everything in self._buffer, but that would
            # deadlock if the subprocess sends more than self.limit
            # bytes.  So just call self.read(self._limit) until EOF.
            blocks = []
            while True:
                block = await self.read(self._limit)
                if not block:
                    break
                blocks.append(block)
            return b''.join(blocks)
    
        if not self._buffer and not self._eof:
>           await self._wait_for_data('read')

../../../.pyenv/versions/3.10.4/lib/python3.10/asyncio/streams.py:669: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <StreamReader transport=<_SelectorSocketTransport closing fd=16>>, func_name = 'read'

    async def _wait_for_data(self, func_name):
        """Wait until feed_data() or feed_eof() is called.
    
        If stream was paused, automatically resume it.
        """
        # StreamReader uses a future to link the protocol feed_data() method
        # to a read coroutine. Running two read coroutines at the same time
        # would have an unexpected behaviour. It would not possible to know
        # which coroutine would get the next data.
        if self._waiter is not None:
            raise RuntimeError(
                f'{func_name}() called while another coroutine is '
                f'already waiting for incoming data')
    
        assert not self._eof, '_wait_for_data after EOF'
    
        # Waiting for data while paused will make deadlock, so prevent it.
        # This is essential for readexactly(n) for case when n > self._limit.
        if self._paused:
            self._paused = False
            self._transport.resume_reading()
    
        self._waiter = self._loop.create_future()
        try:
>           await self._waiter
E           RuntimeError: Task <Task pending name='anyio.from_thread.BlockingPortal._call_func' coro=<BlockingPortal._call_func() running at /Users/mathiasg/.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/anyio/from_thread.py:187> cb=[TaskGroup._spawn.<locals>.task_done() at /Users/mathiasg/.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/anyio/_backends/_asyncio.py:629]> got Future <Future pending> attached to a different loop

../../../.pyenv/versions/3.10.4/lib/python3.10/asyncio/streams.py:502: RuntimeError

During handling of the above exception, another exception occurred:

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x1042462f0>

    def test_graphql_overload(monkeypatch):
        monkeypatch.delitem(os.environ, 'ETELEMETRY_BYPASS_RATE_LIMIT')
>       client.post("/graphql", json={'query': queries['add_project']})

etelemetry_app/tests/test_server.py:50: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/requests/sessions.py:577: in post
    return self.request('POST', url, data=data, json=json, **kwargs)
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/starlette/testclient.py:476: in request
    return super().request(
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/requests/sessions.py:529: in request
    resp = self.send(prep, **send_kwargs)
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/requests/sessions.py:645: in send
    r = adapter.send(request, **kwargs)
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/starlette/testclient.py:270: in send
    raise exc
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/starlette/testclient.py:267: in send
    portal.call(self.app, scope, receive, send)
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/anyio/from_thread.py:240: in call
    return cast(T_Retval, self.start_task_soon(func, *args).result())
../../../.pyenv/versions/3.10.4/lib/python3.10/concurrent/futures/_base.py:446: in result
    return self.__get_result()
../../../.pyenv/versions/3.10.4/lib/python3.10/concurrent/futures/_base.py:391: in __get_result
    raise self._exception
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/anyio/from_thread.py:187: in _call_func
    retval = await retval
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/fastapi/applications.py:269: in __call__
    await super().__call__(scope, receive, send)
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/starlette/applications.py:124: in __call__
    await self.middleware_stack(scope, receive, send)
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/starlette/middleware/errors.py:184: in __call__
    raise exc
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/starlette/middleware/errors.py:162: in __call__
    await self.app(scope, receive, _send)
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/starlette/middleware/cors.py:84: in __call__
    await self.app(scope, receive, send)
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/starlette/exceptions.py:93: in __call__
    raise exc
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/starlette/exceptions.py:82: in __call__
    await self.app(scope, receive, sender)
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py:21: in __call__
    raise e
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py:18: in __call__
    await self.app(scope, receive, send)
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/starlette/routing.py:670: in __call__
    await route.handle(scope, receive, send)
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/starlette/routing.py:266: in handle
    await self.app(scope, receive, send)
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/starlette/routing.py:65: in app
    response = await func(request)
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/fastapi/routing.py:227: in app
    raw_response = await run_endpoint_function(
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/fastapi/routing.py:160: in run_endpoint_function
    return await dependant.call(**values)
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/strawberry/fastapi/router.py:205: in handle_http_post
    return await self.execute_request(
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/strawberry/fastapi/router.py:323: in execute_request
    result = await self.execute(
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/strawberry/fastapi/router.py:290: in execute
    return await self.schema.execute(
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/strawberry/schema/schema.py:183: in execute
    result = await execute(
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/strawberry/schema/execute.py:76: in execute
    async with extensions_runner.request():
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/strawberry/extensions/context.py:27: in __aenter__
    await await_maybe(extension.on_request_start())
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/strawberry/utils/await_maybe.py:12: in await_maybe
    return await value
etelemetry_app/server/schema.py:126: in on_request_start
    await self.sliding_window_rate_limit(request, response)
etelemetry_app/server/schema.py:159: in sliding_window_rate_limit
    res = await pipe.execute()
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/aioredis/client.py:4625: in execute
    return await execute(conn, stack, raise_on_error)
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/aioredis/client.py:4491: in _execute_transaction
    await self.parse_response(connection, "_")
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/aioredis/client.py:1101: in parse_response
    response = await connection.read_response()
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/aioredis/connection.py:910: in read_response
    await self.disconnect()
../../../.pyenv/versions/3.10.4/envs/etelemetry/lib/python3.10/site-packages/aioredis/connection.py:803: in disconnect
    self._writer.close()  # type: ignore[union-attr]
../../../.pyenv/versions/3.10.4/lib/python3.10/asyncio/streams.py:338: in close
    return self._transport.close()
../../../.pyenv/versions/3.10.4/lib/python3.10/asyncio/selector_events.py:697: in close
    self._loop.call_soon(self._call_connection_lost, None)
../../../.pyenv/versions/3.10.4/lib/python3.10/asyncio/base_events.py:750: in call_soon
    self._check_closed()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <_UnixSelectorEventLoop running=False closed=True debug=False>

    def _check_closed(self):
        if self._closed:
>           raise RuntimeError('Event loop is closed')
E           RuntimeError: Event loop is closed

../../../.pyenv/versions/3.10.4/lib/python3.10/asyncio/base_events.py:515: RuntimeError
```

</summary>